### PR TITLE
Unpin/pin working versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible == 2.2.1.0  # https://github.com/ansible/ansible/issues/23016
+ansible
 flake8
-molecule
-setuptools > 0.9.8  # ansible-lint started freaking out about this when I pinned ansible==2.2.1.0
+molecule == 1.25.0
+setuptools
 python-vagrant


### PR DESCRIPTION
Unpin Ansible / setuptools (no more errors in latest versions).

Pin molecule (due to version 2.0rc being released on PyPI and it has a different config format).